### PR TITLE
Fix cleanup loop

### DIFF
--- a/Jamf Client Communications Doctor.sh
+++ b/Jamf Client Communications Doctor.sh
@@ -376,7 +376,7 @@ else
     etime=$(ps -ao etime= ${jamfPid})
     printlog "Process etime is $etime" DEBUG
     if [[ $etime == *"-"* ]]; then
-      days=$(ps -ao etime= $i | cut -d "-" -f1)
+      days=$(ps -ao etime= ${jamfPid} | cut -d "-" -f1)
       printlog "Jamf Policy running for $days days." DEBUG
     else
       printlog "Jamf Policy isn't older than a day." DEBUG


### PR DESCRIPTION
A line similar to `Jamf Client Communications Doctor.sh:384: bad math expression: operator expected at 02:35:41` shows up in our logs several times.

Line 384 reads: `if [[ $days -ge 2 ]]; then`

I believe the `$days` variable is spitting out something in the format of `02:35:41` when it is expecting an integer for the number of days.

The `$i` variable on line 379 appears to be an orphan and and I think that is causing problems. Replacing it with `${jamfPid}` as it is on line 376 seems to resolve the bug. We have tested this change and appearances of "bad math expression" in the logs stopped. After this change we observed this in the logs:
```
JamfClientCommunicationsDoctor : 20230829 : 0-27589 : Jamf Policy running for more than 2 days, killing and refreshing LaunchDaemon
```